### PR TITLE
Add all json files and fix build and install

### DIFF
--- a/h1-lwt-unix.json
+++ b/h1-lwt-unix.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "ocaml": ">=4.3.0",
     "@opam/dune": ">=1.5.0",
-    "h1": ">=1.0.0",
-    "h1-lwt": ">=1.0.0",
+    "h1": "~1.0.0",
+    "h1-lwt": "~1.0.0",
     "@opam/lwt": "*",
     "@opam/faraday-lwt-unix": "*"
   },

--- a/h1-lwt-unix.json
+++ b/h1-lwt-unix.json
@@ -1,0 +1,23 @@
+{
+  "name": "h1-lwt-unix",
+  "version": "1.0.0",
+  "license": "BSD-3-clause",
+  "homepage": "https://github.com/reason-native-web/h1",
+  "bugs": { "url": "https://github.com/reason-native-web/h1/issues" },
+  "esy": {
+    "build": "dune build --only-packages=httpaf-lwt-unix --root=./httpaf --profile=release -j 4",
+    "install": "esy-installer #{self.target_dir / 'default' / 'httpaf-lwt-unix.install'}"
+  },
+  "dependencies": {
+    "ocaml": ">=4.3.0",
+    "@opam/dune": ">=1.5.0",
+    "h1": ">=1.0.0",
+    "h1-lwt": ">=1.0.0",
+    "@opam/lwt": "*",
+    "@opam/faraday-lwt-unix": "*"
+  },
+  "resolutions": {
+    "h1": "link:./httpaf.json",
+    "h1-lwt": "link:./httpaf-lwt.json"
+  }
+}

--- a/h1-lwt.json
+++ b/h1-lwt.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "ocaml": ">=4.3.0",
     "@opam/dune": ">=1.5.0",
-    "h1": ">=1.0.0",
+    "h1": "~1.0.0",
     "@opam/lwt": "*"
   },
   "resolutions": {

--- a/h1-lwt.json
+++ b/h1-lwt.json
@@ -1,0 +1,20 @@
+{
+  "name": "h1-lwt",
+  "version": "1.0.0",
+  "license": "BSD-3-clause",
+  "homepage": "https://github.com/reason-native-web/h1",
+  "bugs": { "url": "https://github.com/reason-native-web/h1/issues" },
+  "esy": {
+    "build": "dune build --only-packages=httpaf-lwt --root=./httpaf --profile=release -j 4",
+    "install": "esy-installer #{self.target_dir / 'default' / 'httpaf-lwt.install'}"
+  },
+  "dependencies": {
+    "ocaml": ">=4.3.0",
+    "@opam/dune": ">=1.5.0",
+    "h1": ">=1.0.0",
+    "@opam/lwt": "*"
+  },
+  "resolutions": {
+    "h1": "link:./httpaf.json"
+  }
+}

--- a/h1.json
+++ b/h1.json
@@ -5,13 +5,13 @@
   "homepage": "https://github.com/reason-native-web/h1",
   "bugs": { "url": "https://github.com/reason-native-web/h1/issues" },
   "esy": {
-    "build": "dune build -p httpaf"
+    "build": "dune build --only-packages=httpaf --profile=release -j 4 --root=./httpaf",
+    "install": "esy-installer #{self.target_dir / 'default' / 'httpaf.install'}"
   },
   "dependencies": {
     "ocaml": ">=4.3.0",
     "@opam/dune": ">=1.5.0",
     "@opam/bigstringaf": ">=0.4.0",
-    "@opam/bigarray-compat": "*",
     "@opam/angstrom": ">=0.9.0",
     "@opam/faraday": ">=0.6.1",
     "@opam/result": "*"


### PR DESCRIPTION
With this we can build morph_server_http with just this.

There are some other libraries that will complain about using `h1`, like `h2` and `piaf`